### PR TITLE
Shelter search grammar

### DIFF
--- a/requires/shelterPage.js
+++ b/requires/shelterPage.js
@@ -176,7 +176,7 @@ class ShelterPage extends Page {
         document.querySelector('#sheltersuccess').
             insertAdjacentHTML('beforeend',
                                '<div id="shelterfound">' + number + ' ' + type + ' type ' +
-                               stageNoun + ' found! (' + names.toString() + ')</div>')
+                               stageNoun + ' found!' + (names.length > 0 ? (' + names.toString() + ')' : '') + '</div>')
     }
     
     searchForImgTitle(key) {

--- a/requires/shelterPage.js
+++ b/requires/shelterPage.js
@@ -164,14 +164,19 @@ class ShelterPage extends Page {
     insertShelterFoundDiv(number, name, img) {
         document.querySelector('#sheltersuccess').
             insertAdjacentHTML('beforeend',
-                               '<div id="shelterfound">' + name + ((number > 1) ? 's' : '') + ' found ' + img + '</div>')
+                               '<div id="shelterfound">' + name + ((number !== 1) ? 's' : '') + ' found ' + img + '</div>')
     }
     insertShelterTypeFoundDiv(number, type, stage, names) {
+        let stageNoun = '';
+        if (stage === 'egg') {
+            stageNoun = stage + (number !== 1 ? 's' : '');
+        } else { // i.e. stage === 'Pokemon'
+            stageNoun = stage;
+        }
         document.querySelector('#sheltersuccess').
             insertAdjacentHTML('beforeend',
-                               '<div id="shelterfound">' + number + ' ' + type + ' ' + stage +
-                               ((number > 1) ? 'types' : 'type') + 'found! (' +
-                               names.toString() + ')</div>')
+                               '<div id="shelterfound">' + number + ' ' + type + ' type ' +
+                               stageNoun + ' found! (' + names.toString() + ')</div>')
     }
     
     searchForImgTitle(key) {


### PR DESCRIPTION
Updated pluralization - egg has a plural (eggs) whereas Pokémon is its own plural, and 0 uses the plural form
Clarified word order - "1 ice type egg found" makes more sense than "1 ice eggtypesfound"
Added spaces