### PR TITLE
Make announcement button (QoL hub) appear clickable

### DIFF
--- a/resources/css/pfqol.css
+++ b/resources/css/pfqol.css
@@ -1,4 +1,10 @@
-/* PokÃ©farm QoL style sheet */
+/* Pokéfarm QoL style sheet */
+
+/* Announcement bar */
+
+#announcements li[data-name="QoL] {
+    cursor: pointer;
+}
 
 /* Shelter Page */
 


### PR DESCRIPTION
Changes the item on the announcement bar to be `cursor: pointer;`, i.e. appear clickable.

Also, minor change, typed in the é for Pokéfarm that was a weird utf mishmash.